### PR TITLE
Tie webgme version to < 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "inherits": "2.0.3",
     "mocha": "^3.2.0",
     "requirejs": "2.1.20",
-    "webgme": "^2.0.0"
+    "webgme": ">=2.0.0 < 2.18.0"
   },
   "dependencies": {
     "agentkeepalive": "2.2.0",


### PR DESCRIPTION
If not tied the build and tests will fail.

2.0.0 will use webgme-engine