### PR TITLE
Fixed null exit code error detection. Closes #12

### DIFF
--- a/node_worker.classes.build.js
+++ b/node_worker.classes.build.js
@@ -4933,7 +4933,7 @@ define('executor-worker/ExecutorWorker', [
 
                                 if (self.wasProcessCanceled(err, signal)) {
                                     jobInfo.status = 'CANCELED';
-                                } else if (err) {
+                                } else if (err !== 0) {
                                     self.logger.error(jobInfo.hash + ' exec error: ' + util.inspect(err));
                                     jobInfo.status = 'FAILED_TO_EXECUTE';
                                 }

--- a/src/ExecutorWorker.js
+++ b/src/ExecutorWorker.js
@@ -240,7 +240,7 @@ define('executor-worker/ExecutorWorker', [
 
                                 if (self.wasProcessCanceled(err, signal)) {
                                     jobInfo.status = 'CANCELED';
-                                } else if (err) {
+                                } else if (err !== 0) {
                                     self.logger.error(jobInfo.hash + ' exec error: ' + util.inspect(err));
                                     jobInfo.status = 'FAILED_TO_EXECUTE';
                                 }


### PR DESCRIPTION
When a process exits involuntarily, the exit code is `null` and this is currently recorded as a successful execution as `null` is falsey.