### PR TITLE
Pass api token to executor client. Closes #14

### DIFF
--- a/src/ExecutorWorker.js
+++ b/src/ExecutorWorker.js
@@ -101,7 +101,8 @@ define('executor-worker/ExecutorWorker', [
             server: parameters.server,
             serverPort: parameters.serverPort,
             httpsecure: parameters.httpsecure,
-            logger: parameters.logger
+            logger: parameters.logger,
+            apiToken: parameters.apiToken
         });
 
         if (parameters.executorNonce) {
@@ -525,6 +526,9 @@ define('executor-worker/ExecutorWorker', [
             var req = superagent.post(self.executorClient.executorUrl + 'worker');
             if (self.executorClient.executorNonce) {
                 req.set('x-executor-nonce', self.executorClient.executorNonce);
+            }
+            if (self.executorClient.apiToken) {
+                req.set('x-api-token', self.executorClient.apiToken);
             }
             req
             //.set('Content-Type', 'application/json')


### PR DESCRIPTION
This adds support for setting a personal access token and uses it to set `x-api-token`. The worker config now supports setting `apiToken`. For example, if you are connecting to "http://localhost:8888", the config.json file should contain:
```
{
  "http://localhost:8888": {
    "apiToken": "<enter api token>"
  }
}
```